### PR TITLE
fix: include python-dotenv dep for keyboard-monitor demo

### DIFF
--- a/keyboard-monitor/requirements.txt
+++ b/keyboard-monitor/requirements.txt
@@ -1,5 +1,6 @@
 SQLAlchemy==2.0.28
 mysqlclient==2.2.4
 pynput==1.7.6
+python-dotenv==1.0.1
 streamlit==1.32.0
 tzlocal==5.2


### PR DESCRIPTION
This closes #12.