### PR TITLE
feat: add another example to ingest metrics from kafka

### DIFF
--- a/kafka-ingestion/build_vector/Dockerfile
+++ b/kafka-ingestion/build_vector/Dockerfile
@@ -5,7 +5,7 @@ FROM rust:1.79 AS builder
 RUN apt-get update && apt-get install -y cmake pkg-config libssl-dev protobuf-compiler libsasl2-dev
 
 # Clone the Vector source code
-RUN git clone --depth 1 -b chore/greptime_log https://github.com/paomian/vector.git /vector
+RUN git clone --depth 1 https://github.com/vectordotdev/vector.git /vector
 WORKDIR /vector
 
 # Build Vector

--- a/kafka-ingestion/config_data/vector.toml
+++ b/kafka-ingestion/config_data/vector.toml
@@ -1,12 +1,19 @@
-[sources.mq]
+[sources.log_mq]
 type = "kafka"
 group_id = "vector0"
-topics = ["test_topic"]
+topics = ["test_log_topic"]
 bootstrap_servers = "kafka:9092"
+
+[sources.metric_mq]
+type = "kafka"
+group_id = "vector0"
+topics = ["test_metric_topic"]
+bootstrap_servers = "kafka:9092"
+decoding.codec = "influxdb"
 
 [sinks.console]
 type = "console"
-inputs = [ "mq" ]
+inputs = [ "log_mq", "metric_mq" ]
 encoding.codec = "text"
 
 [sinks.sink_greptime_logs]
@@ -14,5 +21,10 @@ type = "greptimedb_logs"
 table = "demo_logs"
 pipeline_name = "demo_pipeline"
 compression = "gzip"
-inputs = [ "mq" ]
+inputs = [ "log_mq" ]
 endpoint = "http://greptimedb:4000"
+
+[sinks.sink_greptime_metrics]
+type = "greptimedb"
+inputs = [ "metric_mq" ]
+endpoint = "greptimedb:4001"

--- a/kafka-ingestion/docker-compose.yml
+++ b/kafka-ingestion/docker-compose.yml
@@ -25,7 +25,9 @@ services:
     image: docker.io/bitnami/kafka:3.6.0
     networks:
       - demo-network
-    command: ["/opt/bitnami/kafka/bin/kafka-topics.sh", "--create", "--topic", "test_topic", "--bootstrap-server", "kafka:9092"]
+    command: >
+      /opt/bitnami/kafka/bin/kafka-topics.sh --create --topic test_log_topic --bootstrap-server kafka:9092
+      && /opt/bitnami/kafka/bin/kafka-topics.sh --create --topic test_metric_topic --bootstrap-server kafka:9092
     depends_on:
       kafka:
         condition: service_started
@@ -38,7 +40,8 @@ services:
     networks:
       - demo-network
     environment:
-      - KAFKA_TOPIC_NAME=test_topic
+      - KAFKA_LOG_TOPIC_NAME=test_log_topic
+      - KAFKA_METRIC_TOPIC_NAME=test_metric_topic
     depends_on:
       kafka-init:
         condition: service_completed_successfully

--- a/kafka-ingestion/producer/app.py
+++ b/kafka-ingestion/producer/app.py
@@ -4,13 +4,22 @@ import os
 
 print("starting producer", flush=True)
 
-topic = os.environ["KAFKA_TOPIC_NAME"]
-print("using topic: ", topic, flush=True)
+log_topic = os.environ["KAFKA_LOG_TOPIC_NAME"]
+print("using topic: ", log_topic, flush=True)
+metric_topic = os.environ["KAFKA_METRIC_TOPIC_NAME"]
+print("using topic: ", metric_topic, flush=True)
 
 producer = KafkaProducer(bootstrap_servers="kafka:9092")
 print("using producer: ", producer, flush=True)
 
 while True:
-    producer.send(topic, b"this is a test message")
+    producer.send(
+        log_topic,
+        b'127.0.0.1 - - [04/Sep/2024:15:46:13 -0700] "GET / HTTP/1.1" 200 615 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:130.0) Gecko/20100101 Firefox/130.0"',
+    )
+    producer.send(
+        metric_topic,
+        b"monitor,host=host1 cpu=1.2",
+    )
     print("message sent", flush=True)
     time.sleep(3)


### PR DESCRIPTION
This patch:

1. adds another kafka topic and vector sink to ingest metrics from kafka (the message is in ilp format)
2. switches to vector upstream for a bugfix
