### PR TITLE
feat: introduce greptimedb-common.yml and refactor docker compose configs

### DIFF
--- a/ev-open-telemetry/docker-compose.yml
+++ b/ev-open-telemetry/docker-compose.yml
@@ -1,20 +1,6 @@
+include:
+  - ../greptimedb-common.yml
 services:
-  greptimedb:
-    image: docker.io/greptime/greptimedb:v0.10.0-nightly-20241007
-    command: standalone start --http-addr=0.0.0.0:4000 --rpc-addr=0.0.0.0:4001 --mysql-addr=0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
-    ports:
-      - 4000:4000
-      - 4001:4001
-      - 4002:4002
-      - 4003:4003
-    networks:
-      - demo-network
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:4000/health"]
-      interval: 3s
-      timeout: 3s
-      retries: 5
-
   ev_observer:
     build:
       context: ./ev_observer

--- a/flight-data-ingester/docker-compose.yml
+++ b/flight-data-ingester/docker-compose.yml
@@ -1,22 +1,6 @@
+include:
+  - ../greptimedb-common.yml
 services:
-  greptimedb:
-    image: docker.io/greptime/greptimedb:v0.10.0-nightly-20240930
-    command: standalone start --http-addr=0.0.0.0:4000 --rpc-addr=0.0.0.0:4001 --mysql-addr=0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
-    ports:
-      - 4000:4000
-      - 4001:4001
-      - 4002:4002
-      - 4003:4003
-    networks:
-      - demo-network
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:4000/health"]
-      interval: 3s
-      timeout: 3s
-      retries: 5
-    volumes:
-      - /tmp/greptimedb-demo:/tmp/greptimedb
-
   ingester:
     build:
       context: ./ingester

--- a/grafana-alloy/docker-compose.yml
+++ b/grafana-alloy/docker-compose.yml
@@ -1,3 +1,5 @@
+include:
+  - ../greptimedb-common.yml
 services:
   envsubst:
     image: docker.io/widerplan/envsubst
@@ -10,24 +12,8 @@ services:
         required: false
     init: true
 
-  greptimedb:
-    image: docker.io/greptime/greptimedb:v0.11.0-nightly-20241125
-    command: standalone start --http-addr=0.0.0.0:4000 --rpc-addr=0.0.0.0:4001 --mysql-addr=0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
-    ports:
-      - 4000:4000
-      - 4001:4001
-      - 4002:4002
-      - 4003:4003
-    networks:
-      - demo-network
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://127.0.0.1:4000/health" ]
-      interval: 3s
-      timeout: 3s
-      retries: 5
-
   grafana:
-    image: docker.io/grafana/grafana:11.1.0
+    image: docker.io/grafana/grafana:11.2.0
     ports:
       - 3000:3000
     networks:

--- a/greptimedb-common.yml
+++ b/greptimedb-common.yml
@@ -1,0 +1,16 @@
+services:
+  greptimedb:
+    image: docker.io/greptime/greptimedb:v0.11.2
+    command: standalone start --http-addr=0.0.0.0:4000 --rpc-addr=0.0.0.0:4001 --mysql-addr=0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
+    ports:
+      - 4000:4000
+      - 4001:4001
+      - 4002:4002
+      - 4003:4003
+    networks:
+      - demo-network
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://127.0.0.1:4000/health" ]
+      interval: 3s
+      timeout: 3s
+      retries: 5

--- a/kafka-ingestion/docker-compose.yml
+++ b/kafka-ingestion/docker-compose.yml
@@ -1,3 +1,5 @@
+include:
+  - ../greptimedb-common.yml
 services:
   kafka:
     image: docker.io/bitnami/kafka:3.6.0
@@ -66,22 +68,6 @@ services:
       kafka-init:
         condition: service_completed_successfully
     command: "-c /config_data/vector.toml"
-
-  greptimedb:
-    image: docker.io/greptime/greptimedb:v0.9.3
-    command: standalone start --http-addr=0.0.0.0:4000 --rpc-addr=0.0.0.0:4001 --mysql-addr=0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
-    ports:
-      - 4000:4000
-      - 4001:4001
-      - 4002:4002
-      - 4003:4003
-    networks:
-      - demo-network
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:4000/health"]
-      interval: 3s
-      timeout: 3s
-      retries: 5
 
 networks:
   demo-network:

--- a/nginx-log-metrics/docker-compose.yml
+++ b/nginx-log-metrics/docker-compose.yml
@@ -1,20 +1,6 @@
+include:
+  - ../greptimedb-common.yml
 services:
-  greptimedb:
-    image: docker.io/greptime/greptimedb:v0.11.1
-    command: standalone start --http-addr=0.0.0.0:4000 --rpc-addr=0.0.0.0:4001 --mysql-addr=0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
-    ports:
-      - 4000:4000
-      - 4001:4001
-      - 4002:4002
-      - 4003:4003
-    networks:
-      - demo-network
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://127.0.0.1:4000/health" ]
-      interval: 3s
-      timeout: 3s
-      retries: 5
-
   grafana:
     build:
       context: ./grafana

--- a/postgres-fdw/docker-compose.yml
+++ b/postgres-fdw/docker-compose.yml
@@ -1,3 +1,6 @@
+include:
+  - ../greptimedb-common.yml
+
 services:
   envsubst:
     image: docker.io/widerplan/envsubst
@@ -9,22 +12,6 @@ services:
       - path: "greptime.env"
         required: false
     init: true
-
-  greptimedb:
-    image: docker.io/greptime/greptimedb:v0.11.0
-    command: standalone start --http-addr=0.0.0.0:4000 --rpc-addr=0.0.0.0:4001 --mysql-addr=0.0.0.0:4002 --postgres-addr 0.0.0.0:4003
-    ports:
-      - 4000:4000
-      - 4001:4001
-      - 4002:4002
-      - 4003:4003
-    networks:
-      - demo-network
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://127.0.0.1:4000/health" ]
-      interval: 3s
-      timeout: 3s
-      retries: 5
 
   postgresql:
     image: docker.io/postgres:17


### PR DESCRIPTION
* Adds `greptimedb-common.yml` to start greptimedb as a service.
* Refactor all docker-compose configs to include `../greptimedb-common.yml` instead of duplicated configuration.
* Make it easy to upgrade greptimedb version.