### PR TITLE
fix: wrong link in pg_fdw README

### DIFF
--- a/postgres-fdw/README.md
+++ b/postgres-fdw/README.md
@@ -107,7 +107,7 @@ flowchart LR
 ```
 
 To see how we can configure GreptimeDB for `postgres_fdw` extension, see the
-[init.sh](./docker-entrypoint-initdb/init.sh).
+[init.sh](./docker-entrypoint-initdb.d/init.sh).
 
 ## Run in GreptimeCloud
 


### PR DESCRIPTION
@sunng87 the link in pg_fdw README seems wrong, this patch fix it 