### PR TITLE
chore: fix es demo pipeline error

### DIFF
--- a/elasticsearch-ingestion/configs/greptimedb/nginx-logs-pipeline.yml
+++ b/elasticsearch-ingestion/configs/greptimedb/nginx-logs-pipeline.yml
@@ -1,7 +1,7 @@
 processors:
   - dissect:
       fields:
-        - line
+        - message
       patterns:
         - '%{ip_address} - - [%{timestamp}] "%{http_method} %{request_line}" %{status_code} %{response_size} "-" "%{user_agent}"'
       ignore_missing: true


### PR DESCRIPTION
As a result of the pipeline refactoring, the pipeline now has to use `message` as a key to select a whole line of information when using text/plain input