### PR TITLE
fix: align stragglers with GreptimeDB v1.0.0

### DIFF
--- a/dify-monitoring/docker-compose.yml
+++ b/dify-monitoring/docker-compose.yml
@@ -3,7 +3,7 @@ include:
 
 services:
   greptimedb:
-    image: docker.io/greptime/greptimedb:v1.0.0-rc.2
+    image: docker.io/greptime/greptimedb:v1.0.0
     command: >
       standalone start
       --http-addr=0.0.0.0:4000

--- a/nginx-log-metrics/config_data/init_database.sql
+++ b/nginx-log-metrics/config_data/init_database.sql
@@ -4,7 +4,7 @@ CREATE TABLE "ngx_access_log" (
   "referer" STRING NULL,
   "method" STRING NULL,
   "endpoint" STRING NULL,
-  "trace_id" STRING NULL FULLTEXT,
+  "trace_id" STRING NULL FULLTEXT INDEX,
   "protocol" STRING NULL,
   "status" SMALLINT UNSIGNED NULL,
   "size" DOUBLE NULL,


### PR DESCRIPTION
## Summary

Two v1.0.0 compatibility fixes the prior bump PRs missed:

- **dify-monitoring**: `docker-compose.yml` still pinned `greptime/greptimedb:v1.0.0-rc.2`. It declares its own greptimedb service (for custom network/volume) and doesn't `include: ../greptimedb-common.yml`, so #125's bump didn't touch it. Updated to `v1.0.0`.
- **nginx-log-metrics**: `init_database.sql` used the legacy `FULLTEXT` keyword without `INDEX`. v1.0's SQL parser (`src/sql/src/parsers/create_parser.rs:868-876`) now requires `FULLTEXT INDEX` and rejects the old form with `expect INDEX after FULLTEXT`. Changed `"trace_id" STRING NULL FULLTEXT` → `"trace_id" STRING NULL FULLTEXT INDEX`.

## Audit scope (no changes needed)

I also audited all other demos against v1.0 using local source/docs plus a live v1.0.0 instance via the greptimedb MCP server. Everything else is compatible:

- FLOWs (`uddsketch_state` / `uddsketch_calc` / `date_bin` / `CREATE FLOW ... EXPIRE AFTER ... COMMENT ... SINK TO ...`) in dify-monitoring, genai-observability, opentelemetry-trace-django
- `greptime_trace_v1` pipeline + `opentelemetry_traces` + `span_attributes.*` dot-notation columns
- Default OTLP logs ingestion (no pipeline header)
- Pipeline YAML `index: fulltext` / `index: timestamp` (verified via `dryrun_pipeline`)
- Grafana dashboards (MySQL backticks vs HTTP SQL double-quotes used correctly)
- No deprecated/removed config keys in use (`storage.cache_path`, `flatten_json_object`, old `approx_percentile_cont`, Jaeger time-range header)

## Deferred

`index: tag` in `vector-ingestion/pipeline.yaml` is marked deprecated in v1.0 source (use `inverted`) but still parses correctly — kept out of this PR to minimize scope.

## Test plan

- [ ] `cd dify-monitoring && docker compose config | grep greptime/greptimedb` prints `v1.0.0`
- [ ] `cd nginx-log-metrics && docker compose up -d greptimedb init_database` — `init_database` exits 0 (psql runs the SQL successfully against v1.0)
- [ ] `rg 'greptime/greptimedb:' --glob '*.yml' --glob '*.yaml'` shows only `v1.0.0`